### PR TITLE
fix: Incase of error, handle error

### DIFF
--- a/runtime/voxel.c
+++ b/runtime/voxel.c
@@ -27,7 +27,7 @@ int main(int argc, char* argv[]) {
     fseek(fp, 0, SEEK_SET);
     
     if (fread(data, sizeof(char), size, fp) != size) {
-        fprintf(stderr, "Error reading file content\n");
+        fprintf(stderr, "Error reading file contents\n");
         fclose(fp);
         VOXEL_FREE(data);
         return 1;

--- a/runtime/voxel.c
+++ b/runtime/voxel.c
@@ -25,7 +25,6 @@ int main(int argc, char* argv[]) {
     char* data = (char*)VOXEL_MALLOC(size + 1);
 
     fseek(fp, 0, SEEK_SET);
-    fread(data, sizeof(char), size, fp);
     
     if (fread(data, sizeof(char), size, fp) != size) {
         fprintf(stderr, "Error reading file content\n");

--- a/runtime/voxel.c
+++ b/runtime/voxel.c
@@ -26,6 +26,13 @@ int main(int argc, char* argv[]) {
 
     fseek(fp, 0, SEEK_SET);
     fread(data, sizeof(char), size, fp);
+    
+    if (fread(data, sizeof(char), size, fp) != size) {
+        fprintf(stderr, "Error reading file content\n");
+        fclose(fp);
+        VOXEL_FREE(data);
+        return 1;
+    }
 
     context->code = data;
     context->codeLength = size;


### PR DESCRIPTION
```shell
runtime/voxel.c: In function ‘main’:
runtime/voxel.c:34:5: warning: ignoring return value of ‘fread’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
   34 |     fread(data, sizeof(char), size, fp);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```