### PR TITLE
Add `delete` keyword to delete variables and object items

### DIFF
--- a/src/builtins/core/objects.h
+++ b/src/builtins/core/objects.h
@@ -59,11 +59,9 @@ void voxel_builtins_core_removeObjectItem(voxel_Executor* executor) {
     voxel_Thing* key = voxel_pop(executor);
     voxel_Thing* object = voxel_pop(executor);
 
-    if (!object || object->type != VOXEL_TYPE_OBJECT || object->isLocked || argCount < 2) {
-        return voxel_pushNull(executor);
+    if (object && object->type == VOXEL_TYPE_OBJECT && !object->isLocked && argCount >= 2) {
+        voxel_removeObjectItem(executor->context, object, key);
     }
-
-    voxel_removeObjectItem(executor->context, object, key);
 
     voxel_unreferenceThing(executor->context, key);
     voxel_unreferenceThing(executor->context, object);

--- a/src/declarations.h
+++ b/src/declarations.h
@@ -140,6 +140,7 @@ typedef enum voxel_TokenType {
     VOXEL_TOKEN_TYPE_GET = '?',
     VOXEL_TOKEN_TYPE_SET = ':',
     VOXEL_TOKEN_TYPE_VAR = 'v',
+    VOXEL_TOKEN_TYPE_DELETE = 'D',
     VOXEL_TOKEN_TYPE_POP = 'p',
     VOXEL_TOKEN_TYPE_DUPE = 'd',
     VOXEL_TOKEN_TYPE_OVER = 'o',
@@ -372,6 +373,7 @@ VOXEL_ERRORABLE voxel_destroyScope(voxel_Scope* scope);
 voxel_ObjectItem* voxel_getScopeItem(voxel_Scope* scope, voxel_Thing* key);
 VOXEL_ERRORABLE voxel_setScopeItem(voxel_Scope* scope, voxel_Thing* key, voxel_Thing* value);
 VOXEL_ERRORABLE voxel_setLocalScopeItem(voxel_Scope* scope, voxel_Thing* key, voxel_Thing* value);
+VOXEL_ERRORABLE voxel_removeScopeItem(voxel_Scope* scope, voxel_Thing* key);
 
 voxel_Executor* voxel_newExecutor(voxel_Context* context);
 voxel_Executor* voxel_cloneExecutor(voxel_Executor* executor, voxel_Bool copyValueStack);

--- a/src/executors.h
+++ b/src/executors.h
@@ -260,7 +260,9 @@ VOXEL_ERRORABLE voxel_stepExecutor(voxel_Executor* executor) {
             VOXEL_MUST(voxel_pushOntoList(executor->context, executor->valueStack, scopeValue));
             VOXEL_MUST(voxel_unreferenceThing(executor->context, (voxel_Thing*)getKey.value));
 
-            scopeValue->referenceCount++; // To ensure that builtins don't dereference the thing in the scope
+            if (scopeItem) {
+                scopeValue->referenceCount++; // To ensure that builtins don't dereference the thing in the scope
+            }
 
             break;
         }
@@ -276,6 +278,18 @@ VOXEL_ERRORABLE voxel_stepExecutor(voxel_Executor* executor) {
 
             VOXEL_MUST((token->type == VOXEL_TOKEN_TYPE_VAR ? voxel_setLocalScopeItem : voxel_setScopeItem)(executor->scope, (voxel_Thing*)setKey.value, setValue));
             VOXEL_MUST(voxel_unreferenceThing(executor->context, (voxel_Thing*)setKey.value));
+
+            break;
+        }
+
+        case VOXEL_TOKEN_TYPE_DELETE:
+        {
+            VOXEL_ERRORABLE deleteKey = voxel_popFromList(executor->context, executor->valueStack); VOXEL_MUST(deleteKey);
+
+            VOXEL_ASSERT(deleteKey.value, VOXEL_ERROR_MISSING_ARG);
+
+            VOXEL_MUST(voxel_removeScopeItem(executor->scope, (voxel_Thing*)deleteKey.value));
+            VOXEL_MUST(voxel_unreferenceThing(executor->context, (voxel_Thing*)deleteKey.value));
 
             break;
         }

--- a/src/parser.h
+++ b/src/parser.h
@@ -204,6 +204,7 @@ VOXEL_ERRORABLE voxel_nextToken(voxel_Executor* executor, voxel_Position* positi
         case VOXEL_TOKEN_TYPE_GET:
         case VOXEL_TOKEN_TYPE_SET:
         case VOXEL_TOKEN_TYPE_VAR:
+        case VOXEL_TOKEN_TYPE_DELETE:
         case VOXEL_TOKEN_TYPE_POP:
         case VOXEL_TOKEN_TYPE_DUPE:
         case VOXEL_TOKEN_TYPE_OVER:

--- a/src/scopes.h
+++ b/src/scopes.h
@@ -48,3 +48,17 @@ VOXEL_ERRORABLE voxel_setScopeItem(voxel_Scope* scope, voxel_Thing* key, voxel_T
 VOXEL_ERRORABLE voxel_setLocalScopeItem(voxel_Scope* scope, voxel_Thing* key, voxel_Thing* value) {
     return voxel_setObjectItem(scope->context, scope->things, key, value);
 }
+
+VOXEL_ERRORABLE voxel_removeScopeItem(voxel_Scope* scope, voxel_Thing* key) {
+    voxel_ObjectItem* thisScopeItem = voxel_getObjectItem(scope->things, key);
+
+    if (thisScopeItem) {
+        return voxel_removeObjectItem(scope->context, scope->things, key);
+    }
+
+    if (scope->parentScope) {
+        return voxel_removeScopeItem(scope->context->globalScope, key);
+    }
+
+    return VOXEL_OK;
+}

--- a/test/delete/expected.log
+++ b/test/delete/expected.log
@@ -1,0 +1,8 @@
+Before deletion: hello
+After deletion: null
+Before index accessor deletion: value1
+After index accessor deletion: null
+Attempt deletion of non-object index accessor: null
+Before property accessor deletion: value2
+After property accessor deletion: null
+Attempt deletion of non-object property accessor: null

--- a/test/delete/main.vxl
+++ b/test/delete/main.vxl
@@ -1,0 +1,44 @@
+var value = "hello";
+
+syscall io_out("Before deletion: ");
+syscall io_out(value);
+syscall io_out("\n");
+
+delete value;
+
+syscall io_out("After deletion: ");
+syscall io_out(value);
+syscall io_out("\n");
+
+var object = {
+    "key": "value1",
+    prop: "value2"
+};
+
+syscall io_out("Before index accessor deletion: ");
+syscall io_out(object["key"]);
+syscall io_out("\n");
+
+delete object["key"];
+
+syscall io_out("After index accessor deletion: ");
+syscall io_out(object["key"]);
+syscall io_out("\n");
+
+syscall io_out("Attempt deletion of non-object index accessor: ");
+syscall io_out(value["key"]);
+syscall io_out("\n");
+
+syscall io_out("Before property accessor deletion: ");
+syscall io_out(object.prop);
+syscall io_out("\n");
+
+delete object.prop;
+
+syscall io_out("After property accessor deletion: ");
+syscall io_out(object.prop);
+syscall io_out("\n");
+
+syscall io_out("Attempt deletion of non-object property accessor: ");
+syscall io_out(value.prop);
+syscall io_out("\n");

--- a/test/weak/expected.log
+++ b/test/weak/expected.log
@@ -1,3 +1,5 @@
 Before unreference: hello
 Is weak reference: true
 After unreference: null
+Before global deletion: test
+After global deletion: null

--- a/test/weak/main.vxl
+++ b/test/weak/main.vxl
@@ -19,3 +19,16 @@ syscall io_out("\n");
 syscall io_out("After unreference: ");
 syscall io_out(weakRef.deref());
 syscall io_out("\n");
+
+var globalValue = "test";
+var globalWeakRef = globalValue.weak();
+
+syscall io_out("Before global deletion: ");
+syscall io_out(globalWeakRef.deref());
+syscall io_out("\n");
+
+delete globalValue;
+
+syscall io_out("After global deletion: ");
+syscall io_out(globalWeakRef.deref());
+syscall io_out("\n");

--- a/tools/vxbuild-js/codegen.js
+++ b/tools/vxbuild-js/codegen.js
@@ -20,6 +20,7 @@ export const vxcTokens = {
     GET: byte("?"),
     SET: byte(":"),
     VAR: byte("v"),
+    DELETE: byte("D"),
     POP: byte("p"),
     DUPE: byte("d"),
     OVER: byte("o"),

--- a/tools/vxbuild-js/tokeniser.js
+++ b/tools/vxbuild-js/tokeniser.js
@@ -174,7 +174,7 @@ export function tokenise(sourceContainer) {
             continue;
         }
 
-        if (matchToken(/^(?:syscall|import|as|return|function|class|extends|get|set|this|super|new|var|if|else|while|for|retain|throw|try|catch|enum|break|continue)\b/)) {
+        if (matchToken(/^(?:syscall|import|as|return|function|class|extends|get|set|this|super|new|var|if|else|while|for|retain|throw|try|catch|enum|break|continue|delete)\b/)) {
             addToken(KeywordToken);
             continue;
         }


### PR DESCRIPTION
This PR adds the `delete` keyword, which allows variables and object items to be deleted.

Using `delete variableName;` will remove the variable from the current scope or global scope (whichever is closest), and using `delete object[index];` or `delete object.prop;` will remove the relevant item from the object.